### PR TITLE
ICONS: Removed AJ's World of Discovery from Table of Contents

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -433,7 +433,6 @@
 | ⬜️ | gob | abracadabra         | Once Upon A Time: Abracadabra                                                | |
 | ✅ | gob | littlered           | Once Upon A Time: Little Red Riding Hood                                     | Matt, GandalfTheWhite80 |
 | ⬜️ | gob | onceupon            | Once Upon A Time                                                             | |
-| ⬜️ | gob | ajworld             | A.J.'s World of Discovery                                                    | |
 | ✅ | gob | gob3                | Goblins Quest 3                                                              |Canuma|
 | ✅ | gob | crousti             | Croustibat                                                                   | JenniBee, GandalfTheWhite80 |
 | ⬜️ | gob | lit1                | Lost in Time Part 1                                                          | |


### PR DESCRIPTION
The GameID of ajworld was replaced by adibou1, so ajworld is now obsolete and not longer required.